### PR TITLE
trawl survey biomass

### DIFF
--- a/R/bsai_orox.R
+++ b/R/bsai_orox.R
@@ -1,0 +1,105 @@
+#' raw data query for BSAI Other rockfish
+#'
+#' @param year assessment year
+#' @param akfin_user user name
+#' @param akfin_pwd user password
+#' @param afsc_user user name
+#' @param afsc_pwd user password
+#' @param off_yr if this is an off-year assessment change to TRUE - doesn't work for T4/5 stocks
+#'
+#' @return
+#' @export bsai_orox
+#'
+#' @examples
+bsai_orox <- function(year, akfin_user, akfin_pwd, afsc_user, afsc_pwd, off_yr = NULL){
+
+  # globals ----
+  species = "ROCK" # FIXME! this doesn't work... there are species_group_code = 'THDS' & is.na(species_group_code)) that are also 'other rockfish'
+  # The method to get catch for BSAI other rockfish:
+  # agency_species_codes provided to J Sullivan by I Spies in 2020:
+  bsaiorox_agency_spp <- c(153, 154, 172, 148, 147, 157, 139, 158, 145, 176, 143, 142,
+    150, 156, 155, 175, 149, 159, 166, 146, 184, 137,
+    138, 178, 182, 179)
+  # J Sullivan also started to track GOA orox species in case any of these species start to show up in the GOA:
+  goaorox_agency_spp <- c(179, 182, 178, 138, 137, 184, 146, 149, 155, 156, 147, 148)
+
+  # these are species classified in catch as "Other Rockfish" that occur primarily
+  # in GOA. Keep these in just in case any of these spp start to show up in the
+  # BSAI catch
+  goa_orox3 <- c(179, 182, 178, 138, 137, 184, 146, 149, 155, 156, 147, 148)
+  area = "GOA"
+  # these are the official BSAI other rockfish species lists passed along to J Sullivan from I Spies in 2020
+  afsc_species_ls <- c(30330, # black rockfish
+                       30430, # redstripe rockfish
+                       30470, # yelloweye rockfish
+                       30475, # redbanded rockfish
+                       30535, # harlequin rockfish
+                       30560, # shaprchin rockfish
+                       30600, # yellowmouth rockfish
+                       30030, # longspine thornyhead rockfish
+                       30040, # rockfish unidentified
+                       30100, # silvergray rockfish
+                       30150, # dusky and dark rockfishes unidentified
+                       30152, # dusky rockfish
+                       30170, # darkblotches rockfish
+                       30270, # rosethorn rockfish
+                       30010, # thornyhead rockfish unidentified
+                       30020, # shortspine thornyhead rockfish
+                       30025 # broadfin thornyhead rockfish
+  )
+
+  norpac_species_ls <- c(300, # rockfish unidentified
+                         304, # sharpchin rockfish
+                         308, # redbanded rockfish
+                         309, # rosethorn rockfish
+                         310, # silvergray rockfish
+                         311, # darkblotched rockfish
+                         320, # yellowmouth rockfish
+                         322, # yelloweye rockfish
+                         323, # harlequin rockfish
+                         324, # redstripe rockfish
+                         330, # dusky rockfish
+                         345, # dark rockfish
+                         349, # thornyhead rockfish unidentified
+                         350, # shortspine thornyhead rockfish
+                         351, # broad banded (?) thornyhead rockfish
+                         352, # longspine thornyhead rockfish
+                         306, # black rockfish
+                         355 # dusky/dark rockfish unidentified
+  )
+
+  # establish akfin connection
+  akfin = DBI::dbConnect(odbc::odbc(), "akfin", UID = akfin_user, PWD = akfin_pwd)
+
+  q_ts_total_biomass(year, area = 'EBSSHELF', akfin, afsc_species = afsc_species_ls, save = FALSE) %>% str()
+  q_ts_total_biomass(year, area = 'EBSSLOPE', akfin, afsc_species = afsc_species_ls, save = FALSE) %>% str()
+
+  # q_fish_catch(year, fishery = "fsh", species = species, area = area, akfin = akfin)
+  # q_fish_obs(year, fishery = "fsh", norpac_species = c(norpac_species, norpac_species2),area, akfin)
+  # q_fish_age_comp(year, fishery = "fsh", norpac_species = c(norpac_species, norpac_species2),
+  #                 area = area, akfin = akfin)
+  # q_fish_length_comp(year, fishery = "fsh", norpac_species = c(norpac_species, norpac_species2),
+  #                    area = area, akfin = akfin)
+  # q_lls_biomass(year, area = "goa", afsc_species = afsc_species, akfin = akfin)
+  #
+  # q_lls_length_comp(year, area = "goa", afsc_species = afsc_species, akfin = akfin)
+  #
+  DBI::dbDisconnect(akfin)
+  #
+  #establish afsc connection
+  # afsc = DBI::dbConnect(odbc::odbc(), "afsc",
+  #                       UID = afsc_user, PWD = afsc_pwd)
+  #
+  # afsc_species_n <- c(afsc_species1, afsc_species2,
+  #                     afsc_species3)
+  #
+  # q_ts_biomass(year, area = "ai",
+  #              afsc_species = afsc_species_n, afsc = afsc)
+  #
+  # DBI::dbDisconnect(afsc)
+
+  # gfdata::goa_rebs_catch_1977_2004 %>%
+  #   vroom::vroom_write(here::here(year, "data", "user_input", "goa_rebs_catch_1977_2004.csv"), delim = ",")
+
+  q_date(year)
+}

--- a/R/goa_nork.R
+++ b/R/goa_nork.R
@@ -1,4 +1,4 @@
-#' raw data query for GOA RE/BS
+#' raw data query for GOA northern rockfish
 #'
 #' @param year assessment year
 #' @param akfin_user user name

--- a/R/q_ts_total_biomass.R
+++ b/R/q_ts_total_biomass.R
@@ -1,0 +1,40 @@
+#' trawl survey biomass data query
+#'
+#' @param year assessment year
+#' @param area corresponds to the survey e.g. 'GOA', 'AI', 'EBSSHELF', 'EBSSLOPE',future dev: 'EBSSHELF_PLUSNW', 'EBS_SHELF_STANDARD', etc.
+#' @param afsc_species afsc species code(s)
+#' @param akfin  the database to query
+#' @param save save the file in designated folder
+#'
+#' @return
+#' @export
+#'
+#' @examples
+q_ts_total_biomass <- function (year, area = "GOA", afsc_species, akfin, save = TRUE){
+
+  files <- grep("ts_total_biomass",
+                list.files(system.file("sql", package = "gfdata")), value=TRUE)
+  files <- grep(tolower(area), files, value=TRUE)
+  .bio = sql_read(files[1])
+
+  if(area %in% c("GOA", "AI")) {
+    .bio = sql_filter(x = area, sql_code = .bio, flag = "-- insert area")
+  }
+
+  if(length(afsc_species) == 1) {
+    .bio = sql_filter(x = afsc_species, sql_code = .bio, flag = "-- insert species")
+  } else {
+    .bio = sql_filter(sql_precode = "IN", x = afsc_species,
+                      sql_code = .bio, flag = "-- insert species")
+  }
+
+  if(isTRUE(save)){
+    sql_run(akfin, .bio) %>%
+      write.csv(here::here(year, "data", "raw", paste0(tolower(area), "_ts_total_biomass_data.csv")),
+                row.names = FALSE)
+  } else {
+    sql_run(akfin, .bio)
+  }
+}
+
+

--- a/inst/sql/aigoa_ts_total_biomass.sql
+++ b/inst/sql/aigoa_ts_total_biomass.sql
@@ -1,0 +1,21 @@
+SELECT survey,
+  year,
+  species_code,
+  haul_count,
+  catch_count,
+  mean_wgt_cpue,
+  var_wgt_cpue,
+  mean_num_cpue,
+  var_num_cpue,
+  total_biomass,
+  biomass_var,
+  min_biomass,
+  max_biomass,
+  total_pop,
+  pop_var
+FROM afsc.race_biomasstotalaigoa
+WHERE species_code
+  -- insert species
+  and
+  survey
+  -- insert area

--- a/inst/sql/ebsshelf_standard_ts_total_biomass.sql
+++ b/inst/sql/ebsshelf_standard_ts_total_biomass.sql
@@ -1,0 +1,20 @@
+SELECT survey,
+  year,
+  species_code,
+  haulcount as haul_count,
+  catcount as catch_count,
+  meanwgtcpue as mean_wgt_cpue,
+  varmnwgtcpue as var_wgt_cpue,
+  meannumcpue as mean_num_cpue,
+  varmnnumcpue as var_num_cpue,
+  biomass as total_biomass,
+  varbio as biomass_var,
+  lowerb as min_biomass,
+  upperb as max_biomass,
+  population as total_pop,
+  varpop as pop_var
+FROM afsc.race_biomass_ebsshelf_standard
+WHERE species_code
+  -- insert species
+  and
+  stratum in ('999') -- code for 'all strata combined'

--- a/inst/sql/ebsslope_ts_total_biomass.sql
+++ b/inst/sql/ebsslope_ts_total_biomass.sql
@@ -1,0 +1,20 @@
+SELECT survey,
+  year,
+  species_code,
+  haul_count,
+  catch_count,
+  mean_wgt_cpue,
+  var_wgt_cpue,
+  mean_num_cpue,
+  var_num_cpue,
+  stratum_biomass as total_biomass,
+  bio_var as biomass_var,
+  min_biomass,
+  max_biomass,
+  stratum_pop as total_pop,
+  pop_var
+FROM afsc.race_biomass_ebsslope
+WHERE species_code
+  -- insert species
+  and
+  stratum in ('999999') -- code for 'all strata combined'


### PR DESCRIPTION
@BenWilliams-NOAA based on our conversation today and issue #4:
My thought is to write R functions and queries that correspond to pre-defined levels of biomass (e.g. total biomass, biomass by area, biomass by depth strata). This gets rid of species-specific logic, making the package more broadly applicable. Please note that this pull request is for illustrative purposes... It currently only includes the function and associated queries for total biomass, and would need to be expanded to include functions and queries for biomass by INPFC area and the biomass by depth cases. The biomass by INPFC area is relevant to any stock assessment that needs to split out Southern Bering Sea biomass in the AI survey (for assessment or apportionment) and the biomass by depth is relevant beyond sablefish and should be more generic (e.g., GOA thornyheads fit the RE model by depth). If I have your blessing, please let me know, and I'll get rid of the existing q_ts_biomass.R function, write additional functions for INPFC and depth biomass, and update the species-specific scripts. I will also use this approach to develop IPHC and LLS queries, both of which have similar issues (especially LLS).
